### PR TITLE
openocd-riscv: add mainProgram attribute

### DIFF
--- a/pkgs/openocd-riscv.nix
+++ b/pkgs/openocd-riscv.nix
@@ -99,6 +99,7 @@ stdenv.mkDerivation rec {
     homepage = "https://openocd.sourceforge.net/";
     license = licenses.gpl2Plus;
     platforms = platforms.unix;
+    mainProgram = "openocd";
   };
 }
 


### PR DESCRIPTION
Sets the `mainProgram` attribute to `"openocd"`, which helps Nix identify the main executable for this package (Mainly helpful for `nix bundle`).